### PR TITLE
Stub implementation of static annotation search and plaintext extension

### DIFF
--- a/.annotations_sample
+++ b/.annotations_sample
@@ -1,0 +1,17 @@
+source_path: ../devstack-docker/edx-platform
+report_path: reports
+annotations:
+    pii:
+        - ".. pii::"
+        - ".. pii_types::":
+            choices: [id, name, other]
+        - ".. pii_retirement::":
+            choices: [retained, local_api, consumer_api, third_party]
+    nopii: ".. no_pii::"
+
+extensions:
+    plaintext:
+        - py
+    javascript:
+        - js
+        - jsx

--- a/code_annotations/cli.py
+++ b/code_annotations/cli.py
@@ -6,6 +6,7 @@ import sys
 
 import click
 import yaml
+
 from code_annotations.django_reporting_helpers import get_models_requiring_annotations
 
 DEFAULT_SAFELIST_FILE_PATH = '.pii_safe_list.yaml'

--- a/code_annotations/exceptions.py
+++ b/code_annotations/exceptions.py
@@ -1,0 +1,11 @@
+"""
+Custom exceptions for code_annotations.
+"""
+
+
+class ConfigurationException(Exception):
+    """
+    Exception specific to code annotation configuration problems.
+    """
+
+    pass

--- a/code_annotations/extensions/__init__.py
+++ b/code_annotations/extensions/__init__.py
@@ -1,0 +1,3 @@
+"""
+Extensions used in static annotation functionality.
+"""

--- a/code_annotations/extensions/base.py
+++ b/code_annotations/extensions/base.py
@@ -1,0 +1,32 @@
+"""
+Abstract and base classes to support plugins.
+"""
+
+
+class AnnotationExtension(object):
+    """
+    Abstract base class that annotation extensions will inherit from.
+    """
+
+    def __init__(self, config, echo):
+        """
+        Initialize this base object, save a handle to configuration.
+
+        Args:
+            config: The configuration object
+            echo: VerboseEcho object used for logging
+        """
+        self.config = config
+        self.ECHO = echo
+
+    def validate(self, file_handle):
+        """
+        Validate that any annotations in the given file are properly formatted.
+        """
+        raise NotImplementedError('validate called on base class!')
+
+    def search(self, file_handle):
+        """
+        Search for annotations in the given file.
+        """
+        raise NotImplementedError('search called on base class!')

--- a/code_annotations/extensions/javascript.py
+++ b/code_annotations/extensions/javascript.py
@@ -1,0 +1,38 @@
+"""
+Stevedore extension for static annotation searching in javascript files.
+"""
+
+from .base import AnnotationExtension
+
+
+# TODO: Make this work.
+class JavascriptAnnotationExtension(AnnotationExtension):
+    """
+    Annotation extension for Javascript source files.
+    """
+
+    extension_name = 'javascript'
+
+    def validate(self, file_handle):
+        """
+        Validate that any annotations in the given file are properly formatted.
+
+        Args:
+            file_handle: Open file handle for the file to validate, set to beginning of the file
+
+        Returns:
+            Tuple of (success, list strings describing reasons for failure)
+        """
+        return True
+
+    def search(self, file_handle):
+        """
+        Search for annotations in the given file.
+
+        Args:
+            file_handle: Open file handle for the file to validate, set to beginning of the file
+
+        Returns:
+            List of dicts describing found annotations, or an empty list
+        """
+        return []

--- a/code_annotations/extensions/plaintext.py
+++ b/code_annotations/extensions/plaintext.py
@@ -1,0 +1,104 @@
+"""
+Stevedore extension for static annotation searching in any plain text file.
+"""
+
+import re
+
+import six
+
+from code_annotations.extensions.base import AnnotationExtension
+from code_annotations.helpers import clean_abs_path
+
+
+class PlaintextAnnotationExtension(AnnotationExtension):
+    """
+    Extension for any type of text files.
+    """
+
+    extension_name = 'plaintext'
+
+    def __init__(self, config, echo):
+        """
+        Set up the extension, create the regex used to do searches.
+
+        Args:
+            config: The configuration dict
+            echo: VerboseEcho object for logging
+        Returns:
+            None
+        """
+        super(PlaintextAnnotationExtension, self).__init__(config, echo)
+
+        strings_to_search = []
+        annotation_tokens = config['annotations']
+
+        # Take the configured annotations and turn them into a regex for our search
+
+        # TODO: Refactor this wall of text and extend to enforce groups
+        for annotation_or_group in annotation_tokens:
+            if isinstance(annotation_tokens[annotation_or_group], six.string_types):
+                strings_to_search.append(annotation_tokens[annotation_or_group])
+            elif isinstance(annotation_tokens[annotation_or_group], (list, tuple)):
+                group = annotation_tokens[annotation_or_group]
+                for annotation in group:
+                    if isinstance(annotation, six.string_types):
+                        strings_to_search.append(annotation)
+                    elif isinstance(annotation, dict):
+                        strings_to_search.append(list(annotation.keys())[0])
+                    else:
+                        raise TypeError('{} is an unknown type. Annotations must be strings or list/tuples.'.format(
+                            annotation_tokens[annotation_or_group])
+                        )
+            else:
+                raise TypeError('{} is an unknown type. Annotations must be strings or list/tuples.'.format(
+                    annotation_tokens[annotation_or_group])
+                )
+
+        self.query = r'{}'.format('|'.join(strings_to_search))
+
+        self.ECHO.echo_v("Plaintext extension regex query: {}".format(self.query))
+
+    def validate(self, file_handle):
+        """
+        Validate any annotations in the given file are properly formatted.
+
+        Args:
+            file_handle: Open file handle for the file to validate
+
+        Returns:
+            Tuple of (success, list strings describing reasons for failure)
+        """
+        # TODO: Implement!
+        return True
+
+    def search(self, file_handle):
+        """
+        Search for annotations in the given file.
+
+        Args:
+            file_handle: Handle for the file to validate
+
+        Returns:
+            List of dicts describing found annotations, or an empty list
+        """
+        txt = file_handle.read()
+        found_annotations = []
+
+        # Fast out if no annotations exist in the file
+        if re.search(self.query, txt):
+            line_num = 0
+            for line in txt.splitlines():
+                line_num += 1
+                for m in re.finditer(self.query, line):
+                    token = line[m.start():m.end()].strip()
+                    substring = line[m.end():None].strip()
+
+                    found_annotations.append({
+                        'found_by': self.extension_name,
+                        'filename': clean_abs_path(file_handle.name, self.config['source_path']),
+                        'line_number': line_num,
+                        'annotation_token': token,
+                        'annotation_data': substring
+                    })
+
+        return found_annotations

--- a/code_annotations/find_annotations.py
+++ b/code_annotations/find_annotations.py
@@ -1,0 +1,273 @@
+"""
+Click command to do static annotation searching via Stevedore plugins.
+"""
+import datetime
+import errno
+import os
+
+import click
+import yaml
+from stevedore import named
+
+from code_annotations.exceptions import ConfigurationException
+from code_annotations.helpers import VerboseEcho
+
+# Global logger for this script, shared with extensions
+ECHO = VerboseEcho()
+
+
+def load_failed_handler(*args, **kwargs):
+    """
+    Handle failures to load an extension.
+
+    Dumps the error and raises an exception. By default these
+    errors just fail silently.
+
+    Args:
+        *args:
+        **kwargs:
+
+    Returns:
+        None
+
+    Raises:
+        ConfigurationException
+    """
+    ECHO.echo(args)
+    ECHO.echo(kwargs)
+    raise ConfigurationException('Failed to load a plugin, aborting.')
+
+
+def search_extension(ext, file_handle, file_extensions_map, filename_extension):
+    """
+    Execute a search on the given file using the given extension.
+
+    Args:
+        ext: Extension to execute the search on
+        file_handle: An open file handle search
+        file_extensions_map: Dict mapping of extension names to configured filename extensions
+        filename_extension: The filename extension of the file being searched
+
+    Returns:
+        Tuple of (extension name, list of found annotation dicts)
+    """
+    # Reset the read handle to the beginning of the file in case another
+    # extension already moved it
+    file_handle.seek(0)
+
+    # Only search this file if we are configured for its extension
+    if filename_extension in file_extensions_map[ext.name]:
+        ext_results = ext.obj.search(file_handle)
+
+        if ext_results:
+            return ext.name, ext_results
+
+    return ext.name, None
+
+
+def format_file_results(all_results, results):
+    """
+    Add all extensions' search results for a file to the overall results.
+
+    Args:
+        all_results: Aggregated results to add the results to
+        results: Results of search() on a single file
+
+    Returns:
+        None, modifies all_results
+    """
+    # _ here is the extension name, as required by Stevedore map(). Each
+    # annotation already has the extension name so we can ignore it here
+    for _, annotations in results:
+        if annotations is None:
+            continue
+
+        # TODO: The file_path should be the same for all of these results
+        # so we should be able to optimize getting file_path and making
+        # sure it exists in the dict to do this less often.
+        file_path = annotations[0]['filename']
+
+        if file_path not in all_results:
+            all_results[file_path] = []
+
+        # TODO: add support for multiple extensions in the 'found_by' key
+        # and de-dupe results
+        all_results[file_path].extend(annotations)
+
+
+def configure(config, source_path, report_path, verbosity):
+    """
+    Read the configuration file, and handle command line overrides.
+
+    Args:
+        config: Location of the configuration file
+        source_path: Path to the code to be searched
+        report_path: Directory where the report will be generated
+        verbosity: Integer indicating the runtime verbosity level
+
+    Returns:
+        Configuration dict, updated with overrides
+    """
+    # TODO: Add include / exclude directories
+    ECHO.echo('Reading configuration from {}'.format(config))
+
+    with open(config) as config_file:
+        config = yaml.load(config_file)
+
+    if not source_path and not config['source_path']:
+        raise ConfigurationException('source_path not given and not in configuration file')
+
+    if not report_path and not config['report_path']:
+        raise ConfigurationException('report_path not given and not in configuration file')
+
+    if source_path:
+        config['source_path'] = source_path
+
+    if report_path:
+        config['report_path'] = report_path
+
+    # This is a runtime option, shouldn't be in the config file
+    config['verbosity'] = verbosity
+
+    ECHO.set_verbosity(verbosity)
+    ECHO.echo_v("Verbosity level set to {}".format(config['verbosity']))
+    ECHO.echo_v("Configuration:")
+    ECHO.echo_v(config)
+
+    return config
+
+
+def search(mgr, config):
+    """
+    Walk the source tree, send known file types to extensions.
+
+    Args:
+        mgr: Stevedore NamedExtensionManager
+        config: Configuration dict
+
+    Returns:
+        Dict containing all of the search results
+    """
+    # Index the results by extension name
+    file_extensions_map = {}
+    known_extensions = set()
+    for extension_name in config['extensions']:
+        file_extensions_map[extension_name] = config['extensions'][extension_name]
+        known_extensions.update(config['extensions'][extension_name])
+
+    all_results = {}
+
+    for root, _, files in os.walk(config['source_path']):
+        for filename in files:
+            filename_extension = os.path.splitext(filename)[1][1:]
+
+            if filename_extension not in known_extensions:
+                ECHO.echo_vvv("{} is not a known extension, skipping ({}).".format(filename_extension, filename))
+                continue
+
+            full_name = os.path.join(root, filename)
+
+            ECHO.echo_vvv(full_name)
+
+            # TODO: This should probably be a generator so we don't have to store all results in memory
+            with open(full_name, 'r') as file_handle:
+                # Call search_extension on all loaded extensions
+                results = mgr.map(search_extension, file_handle, file_extensions_map, filename_extension)
+
+                # Format and add the results to our running full set
+                format_file_results(all_results, results)
+
+    return all_results
+
+
+def report(all_results, config):
+    """
+    Genrates the YAML report of all search results.
+
+    Args:
+        all_results: Dict of found annotations, indexed by filename
+        config: Configuration dict
+
+    Returns:
+        Filename of generated report
+    """
+    ECHO.echo_vv(yaml.dump(all_results, default_flow_style=False))
+
+    now = datetime.datetime.now()
+    report_filename = os.path.join(config['report_path'], '{}.yaml'.format(now.strftime('%Y-%d-%m-%H-%M-%S')))
+
+    ECHO.echo("Generating report to {}".format(report_filename))
+
+    try:
+        os.makedirs(config['report_path'])
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+    with open(report_filename, 'w+') as report_file:
+        yaml.dump(all_results, report_file, default_flow_style=False)
+
+    return report_filename
+
+
+@click.command('static_find_annotations')
+@click.option(
+    '--config_file',
+    default='.annotations',
+    help='Path to the configuration file',
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True)
+)
+@click.option(
+    '--source_path',
+    default=None,
+    help='Location of the source code to search',
+    type=click.Path(exists=True, dir_okay=True, resolve_path=True)
+)
+@click.option('--report_path', default=None, help='Location to write the report')
+@click.option('-v', '--verbosity', count=True, help='Verbosity level (-v through -vvv)')
+def static_find_annotations(config_file, source_path, report_path, verbosity):
+    """
+    Click command to find annotations via static file analysis.
+
+    Args:
+        config_file: Path to the configuration file
+        source_path: Location of the source code to search
+        report_path: Location to write the report
+        verbosity: Verbosity level for output
+
+    Returns:
+        None
+    """
+    now = datetime.datetime.now()
+
+    config = configure(config_file, source_path, report_path, verbosity)
+
+    ECHO.echo("Configured for source path: {}, report path: {}".format(config['source_path'], config['report_path']))
+
+    # These are the names of all of our configured extensions
+    configured_extension_names = config['extensions'].keys()
+
+    ECHO.echo_vv("Configured extension names: {}".format(" ".join(configured_extension_names)))
+
+    # Load Stevedore extensions that we are configured for (and only those)
+    mgr = named.NamedExtensionManager(
+        names=configured_extension_names,
+        namespace='annotation_finder.searchers',
+        invoke_on_load=True,
+        on_load_failure_callback=load_failed_handler,
+        invoke_args=(config, ECHO),
+    )
+
+    # Output all found extension entry points (whether or not they were loaded)
+    ECHO.echo_vv("Stevedore entry points found: {}".format(str(mgr.list_entry_points())))
+
+    # Output all extensions that were actually able to load
+    ECHO.echo_v("Loaded extensions: {}".format(" ".join([x.name for x in mgr.extensions])))
+
+    all_results = search(mgr, config)
+    report_filename = report(all_results, config)
+
+    done = datetime.datetime.now()
+    elapsed = done - now
+
+    ECHO.echo("Report completed in {}: {}".format(elapsed, report_filename))

--- a/code_annotations/helpers.py
+++ b/code_annotations/helpers.py
@@ -1,0 +1,90 @@
+"""
+Helpers for code_annotations scripts.
+"""
+import os
+
+import click
+
+
+class VerboseEcho(object):
+    """
+    Helper to handle verbosity-dependent logging.
+    """
+
+    verbosity = 1
+
+    def set_verbosity(self, verbosity):
+        """
+        Override the default verbosity level.
+
+        Args:
+            verbosity: The verbosity level to set to
+
+        Returns:
+            None
+        """
+        self.verbosity = verbosity
+
+    def echo(self, output, verbosity_level=0):
+        """
+        Echo the given output, if over the verbosity threshold.
+
+        Args:
+            output: Text to output
+            verbosity_level: Only output if our verbosity level is >= this.
+
+        Returns:
+            None
+        """
+        if verbosity_level <= self.verbosity:
+            click.echo(output)
+
+    def echo_v(self, output):
+        """
+        Echo the given output if verbosity level is >= 1.
+
+        Args:
+            output: Text to output
+
+        Returns:
+            None
+        """
+        self.echo(output, 1)
+
+    def echo_vv(self, output):
+        """
+        Echo the given output if verbosity level is >= 2.
+
+        Args:
+            output: Text to output
+
+        Returns:
+            None
+        """
+        self.echo(output, 2)
+
+    def echo_vvv(self, output):
+        """
+        Echo the given output if verbosity level is >= 3.
+
+        Args:
+            output: Text to output
+
+        Returns:
+            None
+        """
+        self.echo(output, 3)
+
+
+def clean_abs_path(filename_to_clean, parent_path):
+    """
+    Safely strips the parent path from the given filename, leaving only the relative path.
+
+    Args:
+        filename_to_clean: Input filename
+        parent_path: Path to remove from the input
+
+    Returns:
+        Updated path
+    """
+    return os.path.relpath(filename_to_clean, parent_path)

--- a/code_annotations/helpers.py
+++ b/code_annotations/helpers.py
@@ -4,6 +4,7 @@ Helpers for code_annotations scripts.
 import os
 
 import click
+import yaml
 
 
 class VerboseEcho(object):
@@ -88,3 +89,17 @@ def clean_abs_path(filename_to_clean, parent_path):
         Updated path
     """
     return os.path.relpath(filename_to_clean, parent_path)
+
+
+def read_configuration(config_file_path):
+    """
+    Read the given yaml configuration file, return the results.
+
+    Args:
+        config_file_path: The path to the configuration file
+
+    Returns:
+        Results of yaml.read() on the file
+    """
+    with open(config_file_path) as config_file:
+        return yaml.load(config_file)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,6 @@
 # Core requirements for using this application
 
-Django>=1.11,<2.0          # Web application framework
 click>=7.0,<8.0
+Django>=1.11,<2.0          # Web application framework
 pyyaml
+stevedore

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,5 +6,8 @@
 #
 click==7.0
 django==1.11.16
+pbr==5.1.1                # via stevedore
 pytz==2018.7              # via django
 pyyaml==3.13
+six==1.11.0               # via stevedore
+stevedore==1.30.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -51,6 +51,7 @@ pyyaml==3.13
 requests==2.20.1
 six==1.11.0
 snowballstemmer==1.2.1
+stevedore==1.30.0
 toml==0.10.0
 tox-battery==0.5.1
 tox==3.5.3

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -40,6 +40,6 @@ six==1.11.0
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.8.2
 sphinxcontrib-websupport==1.1.0  # via sphinx
-stevedore==1.30.0         # via doc8
+stevedore==1.30.0
 urllib3==1.24.1           # via requests
 webencodings==0.5.1       # via bleach

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -42,5 +42,6 @@ pyyaml==3.13
 requests==2.20.1          # via caniusepython3
 six==1.11.0
 snowballstemmer==1.2.1    # via pydocstyle
+stevedore==1.30.0
 urllib3==1.24.1           # via requests
 wrapt==1.10.11            # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,11 +11,12 @@ coverage==4.5.2           # via pytest-cov
 django==1.11.16
 mock==2.0.0
 more-itertools==4.3.0     # via pytest
-pbr==5.1.1                # via mock
+pbr==5.1.1
 pluggy==0.8.0             # via pytest
 py==1.7.0                 # via pytest
 pytest-cov==2.6.0
 pytest==4.0.1             # via pytest-cov
 pytz==2018.7
 pyyaml==3.13
-six==1.11.0               # via mock, more-itertools, pytest
+six==1.11.0
+stevedore==1.30.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 indent='    '
 line_length = 120
 multi_line_output=3
+known_first_party=code_annotations
 
 [wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,11 @@ setup(
     entry_points={
         'console_scripts': [
             'code_annotations = code_annotations.cli:cli',
+            'find_annotations = code_annotations.find_annotations:static_find_annotations',
+        ],
+        'annotation_finder.searchers': [
+            'plaintext = code_annotations.extensions.plaintext:PlaintextAnnotationExtension',
+            'javascript = code_annotations.extensions.javascript:JavascriptAnnotationExtension',
         ],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'code_annotations = code_annotations.cli:cli',
-            'find_annotations = code_annotations.find_annotations:static_find_annotations',
+            'code_annotations = code_annotations.cli:entry_point',
         ],
         'annotation_finder.searchers': [
             'plaintext = code_annotations.extensions.plaintext:PlaintextAnnotationExtension',

--- a/tests/test_code_annotations.py
+++ b/tests/test_code_annotations.py
@@ -10,7 +10,7 @@ import os
 from click.testing import CliRunner
 from mock import DEFAULT, patch
 
-from code_annotations.cli import cli
+from code_annotations.cli import entry_point
 
 FAKE_SAFELIST_PATH = 'fake_safelist_path.yaml'
 
@@ -34,10 +34,8 @@ def _call_script(args_list, test_filesystem_cb=None):
             f.write(FAKE_CONFIG_FILE)
 
         result = runner.invoke(
-            cli,
-            args=[
-                '--config_file', 'test_config.yml',
-            ] + args_list
+            entry_point,
+            args_list
         )
         if test_filesystem_cb:
             test_filesystem_cb()
@@ -77,7 +75,7 @@ def test_seeding_safelist(**kwargs):
             assert model_id not in fake_safelist
 
     result = _call_script(
-        ['pii_report_django', '--seed_safelist'],
+        ['pii_report_django', '--config_file', 'test_config.yml', '--seed_safelist'],
         test_filesystem_cb=test_safelist_callback,
     )
     assert result.exit_code == 0

--- a/tests/test_code_annotations.py
+++ b/tests/test_code_annotations.py
@@ -8,8 +8,9 @@ from __future__ import absolute_import, unicode_literals
 import os
 
 from click.testing import CliRunner
-from code_annotations.cli import cli
 from mock import DEFAULT, patch
+
+from code_annotations.cli import cli
 
 FAKE_SAFELIST_PATH = 'fake_safelist_path.yaml'
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,5 +67,5 @@ commands =
     rm tests/__init__.py
     pycodestyle code_annotations tests setup.py
     pydocstyle code_annotations tests setup.py
-    isort --check-only --diff --recursive tests test_utils code_annotations setup.py test_settings.py
+    isort --check-only --diff --recursive tests test_utils code_annotations setup.py
     make selfcheck


### PR DESCRIPTION
**Description:** A skeleton implementation of static annotation configuration, search, reporting, and extensions.

**JIRA:** PLAT-2350, PLAT-2361, PLAT-2365

**Installation instructions:** To test with the extensions you will need to install the package with `pip install --editable .`

**Testing instructions:**

0. Make sure the package is installed as above
1. Add some annotations to various files
2. Use the `.annotations_sample` as a template to create your own config file, or just point to it on the command line if you're using the `.. pii::` annotations
3. Run `find_annotations`. If things are misbehaving try the various levels of verbosity (`-v` - `-vvv`)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
- There are a lot of TODO items, mostly things to be addressed in other tickets in this epic
- There are no tests currently as those should be done with the tickets to flesh out this skeleton
- The current implementation of the `plaintext` extension started out as the `python` one, but can be used generically. If we want to limit the Python extension to just Python comments we can build on this, but this was in a good enough state to merge as an example.
