### PR TITLE
Allow static linting and reporting to be turned on and off separately

### DIFF
--- a/code_annotations/find_annotations.py
+++ b/code_annotations/find_annotations.py
@@ -295,7 +295,7 @@ class StaticSearch(object):
                 )
             )
 
-    def _check_results(self, all_results):
+    def check_results(self, all_results):
         """
         Spin through all search results, confirm that they all match configuration.
 
@@ -419,8 +419,6 @@ class StaticSearch(object):
         Returns:
             Filename of the generated report
         """
-        start_time = datetime.datetime.now()
-
         # Index the results by extension name
         file_extensions_map = {}
         known_extensions = set()
@@ -438,22 +436,7 @@ class StaticSearch(object):
                     full_name = os.path.join(root, filename)
                     self._search_one_file(full_name, known_extensions, file_extensions_map, all_results)
 
-        # Check grouping and choices
-        self._check_results(all_results)
-
-        # If there are any errors, do not generate the report
-        if self.errors:
-            self.echo("{} errors:".format(len(self.errors)))
-            self.echo("---------------------------------")
-            self.echo("\n".join(self.errors))
-            self.echo("\nReport failed due to errors!")
-            exit(-1)
-
-        annotation_count, report_filename = self.report(all_results)
-        done = datetime.datetime.now()
-        elapsed = done - start_time
-
-        self.echo("Report found {} annotations in {}: {}".format(annotation_count, elapsed, report_filename))
+        return all_results
 
     def report(self, all_results):
         """
@@ -481,8 +464,4 @@ class StaticSearch(object):
         with open(report_filename, 'w+') as report_file:
             yaml.dump(all_results, report_file, default_flow_style=False)
 
-        annotation_count = 0
-        for filename in all_results:
-            annotation_count += len(all_results[filename])
-
-        return annotation_count, report_filename
+        return report_filename

--- a/code_annotations/helpers.py
+++ b/code_annotations/helpers.py
@@ -12,7 +12,7 @@ def fail(msg):
     """
     Log the message and exit.
     """
-    click.echo(msg)
+    click.secho(msg, fg="red")
     sys.exit(-1)
 
 

--- a/tests/extensions/test_extension_javascript.py
+++ b/tests/extensions/test_extension_javascript.py
@@ -7,9 +7,9 @@ from tests.helpers import EXIT_CODE_FAILURE, EXIT_CODE_SUCCESS, call_script
 
 
 @pytest.mark.parametrize("test_file,expected_exit_code,expected_message", [
-    ('simple_success.js', EXIT_CODE_SUCCESS, "Report found 26 annotations in"),
-    ('group_ordering_1.js', EXIT_CODE_SUCCESS, "Report found 3 annotations in"),
-    ('group_ordering_2.js', EXIT_CODE_SUCCESS, "Report found 9 annotations in"),
+    ('simple_success.js', EXIT_CODE_SUCCESS, "Search found 26 annotations in"),
+    ('group_ordering_1.js', EXIT_CODE_SUCCESS, "Search found 3 annotations in"),
+    ('group_ordering_2.js', EXIT_CODE_SUCCESS, "Search found 9 annotations in"),
     ('group_failures_1.js', EXIT_CODE_FAILURE, "File finished with an incomplete group"),
     ('group_failures_2.js', EXIT_CODE_FAILURE, " .. pii_types:: is a member of a group, but"),
     ('group_failures_3.js', EXIT_CODE_FAILURE, "File finished with an incomplete group"),
@@ -33,4 +33,4 @@ def test_grouping_and_choice_failures(test_file, expected_exit_code, expected_me
     assert expected_message in result.output
 
     if expected_exit_code == EXIT_CODE_FAILURE:
-        assert "Report failed due to errors!" in result.output
+        assert "Search failed due to linting errors!" in result.output

--- a/tests/extensions/test_extension_python.py
+++ b/tests/extensions/test_extension_python.py
@@ -7,9 +7,9 @@ from tests.helpers import EXIT_CODE_FAILURE, EXIT_CODE_SUCCESS, call_script
 
 
 @pytest.mark.parametrize("test_file,expected_exit_code,expected_message", [
-    ('simple_success.pyt', EXIT_CODE_SUCCESS, "Report found 20 annotations in"),
-    ('group_ordering_1.pyt', EXIT_CODE_SUCCESS, "Report found 3 annotations in"),
-    ('group_ordering_2.pyt', EXIT_CODE_SUCCESS, "Report found 9 annotations in"),
+    ('simple_success.pyt', EXIT_CODE_SUCCESS, "Search found 20 annotations in"),
+    ('group_ordering_1.pyt', EXIT_CODE_SUCCESS, "Search found 3 annotations in"),
+    ('group_ordering_2.pyt', EXIT_CODE_SUCCESS, "Search found 9 annotations in"),
     ('group_failures_1.pyt', EXIT_CODE_FAILURE, "File finished with an incomplete group"),
     ('group_failures_2.pyt', EXIT_CODE_FAILURE, " .. pii_types:: is a member of a group, but"),
     ('group_failures_3.pyt', EXIT_CODE_FAILURE, "File finished with an incomplete group"),
@@ -31,4 +31,4 @@ def test_grouping_and_choice_failures(test_file, expected_exit_code, expected_me
     assert expected_message in result.output
 
     if expected_exit_code == EXIT_CODE_FAILURE:
-        assert "Report failed due to errors!" in result.output
+        assert "Search failed due to linting errors!" in result.output

--- a/tests/test_find_annotations.py
+++ b/tests/test_find_annotations.py
@@ -43,7 +43,7 @@ def test_unknown_file_extension():
     ))
     assert result.exit_code == EXIT_CODE_SUCCESS
     assert 'nothing is not a known extension, skipping' in result.output
-    assert 'Report found 0 annotations' in result.output
+    assert 'Search found 0 annotations' in result.output
 
 
 def test_file_walking():
@@ -110,4 +110,34 @@ def test_no_extension_results():
         '-v',
     ))
     assert result.exit_code == EXIT_CODE_SUCCESS
-    assert "Report found 0 annotations" in result.output
+    assert "Search found 0 annotations" in result.output
+
+
+def test_no_report():
+    result = call_script((
+        'static_find_annotations',
+        '--config_file',
+        'tests/test_configurations/.annotations_test_python_only',
+        '--source_path=tests/extensions/python_test_files/simple_success.pyt',
+        '--no_report',
+        '-v',
+    ))
+    assert result.exit_code == EXIT_CODE_SUCCESS
+    assert "Search found 20 annotations" in result.output
+    assert "Writing report..." not in result.output
+    assert "Linting passed without errors." in result.output
+
+
+def test_no_lint():
+    result = call_script((
+        'static_find_annotations',
+        '--config_file',
+        'tests/test_configurations/.annotations_test_python_only',
+        '--source_path=tests/extensions/python_test_files/simple_success.pyt',
+        '--no_lint',
+        '-v',
+    ))
+    assert result.exit_code == EXIT_CODE_SUCCESS
+    assert "Search found 20 annotations" in result.output
+    assert "Linting passed without errors." not in result.output
+    assert "Writing report..." in result.output


### PR DESCRIPTION
**Description:** Adds new options `lint/no-lint` and `report/no-report` to allow the linting and reporting functionality to be run separately. Both default to being on. Since the linting actually occurs at the script level no language extension changes were needed.

**JIRA:** PLAT-2349, PLAT-2353