### PR TITLE
Fix coverage count of safelisted Django models

### DIFF
--- a/code_annotations/__init__.py
+++ b/code_annotations/__init__.py
@@ -4,4 +4,4 @@ Extensible tools for parsing annotations in codebases.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/code_annotations/base.py
+++ b/code_annotations/base.py
@@ -220,8 +220,8 @@ class AnnotationConfig(object):
         Raises:
             ConfigurationException
         """
-        self.echo(args)
-        self.echo(kwargs)
+        self.echo(str(args), fg='red')
+        self.echo(str(kwargs), fg='red')
         raise ConfigurationException('Failed to load a plugin, aborting.')
 
     def _configure_extensions(self):

--- a/code_annotations/find_django.py
+++ b/code_annotations/find_django.py
@@ -64,7 +64,7 @@ class DjangoSearch(BaseSearch):
 
         with open(self.config.safelist_path, 'w') as safelist_file:
             safelist_comment = """
-# This is a Code Annotations automatically generated Django model safelist file.
+# This is a Code Annotations automatically-generated Django model safelist file.
 # These models must be annotated as follows in order to be counted in the coverage report.
 # See https://code-annotations.readthedocs.io/en/latest/safelist.html for more information.
 #

--- a/code_annotations/find_django.py
+++ b/code_annotations/find_django.py
@@ -63,12 +63,24 @@ class DjangoSearch(BaseSearch):
         safelist_data = {self.get_model_id(model): {} for model in self.non_local_models}
 
         with open(self.config.safelist_path, 'w') as safelist_file:
-            yaml_ordered_dump(safelist_data, stream=safelist_file)
+            safelist_comment = """
+# This is a Code Annotations automatically generated Django model safelist file.
+# These models must be annotated as follows in order to be counted in the coverage report.
+# See https://code-annotations.readthedocs.io/en/latest/safelist.html for more information.
+#
+# fake_app_1.FakeModelName:
+#    ".. no_pii::": "This model has no PII"
+# fake_app_2.FakeModel2:
+#    ".. choice_annotation::": foo, bar, baz
 
-        self.echo('Successfully created safelist file "{}".'.format(self.config.safelist_path))
-        self.echo('Now, you need to:')
-        self.echo('  1) Make sure that any un-annotated models in the safelist are annotated, and')
-        self.echo('  2) Annotate any LOCAL models (see --list_local_models).')
+            """
+            safelist_file.write(safelist_comment.strip())
+            yaml_ordered_dump(safelist_data, stream=safelist_file, default_flow_style=False)
+
+        self.echo('Successfully created safelist file "{}".'.format(self.config.safelist_path), fg='red')
+        self.echo('Now, you need to:', fg='red')
+        self.echo('  1) Make sure that any un-annotated models in the safelist are annotated, and', fg='red')
+        self.echo('  2) Annotate any LOCAL models (see --list_local_models).', fg='red')
 
     def list_local_models(self):
         """
@@ -228,6 +240,8 @@ class DjangoSearch(BaseSearch):
                     self.uncovered_model_ids.add(model_id)
                     self.echo.echo_vv("      {} is in the safelist.".format(model_id))
                     self._add_error("{} is in the safelist but has no annotations!".format(model_id))
+                else:
+                    self._increment_count('annotated')
 
                 self._append_safelisted_model_annotations(safelisted_models, model_id, model_annotations)
                 self.format_file_results(annotated_models, [model_annotations])

--- a/code_annotations/helpers.py
+++ b/code_annotations/helpers.py
@@ -97,7 +97,7 @@ class VerboseEcho(object):
 
     verbosity = 1
 
-    def __call__(self, output):
+    def __call__(self, output, **kwargs):
         """
         Echo the given output regardless of verbosity level.
 
@@ -105,8 +105,9 @@ class VerboseEcho(object):
 
         Args:
             output: Text to output
+            kwargs: Any additional keyword args to pass to click.echo
         """
-        self.echo(output)
+        self.echo(output, **kwargs)
 
     def set_verbosity(self, verbosity):
         """
@@ -114,50 +115,52 @@ class VerboseEcho(object):
 
         Args:
             verbosity: The verbosity level to set to
-
-        Returns:
-            None
+            kwargs: Any additional keyword args to pass to click.echo
         """
         self.verbosity = verbosity
         self.echo_v("Verbosity level set to {}".format(verbosity))
 
-    def echo(self, output, verbosity_level=0):
+    def echo(self, output, verbosity_level=0, **kwargs):
         """
         Echo the given output, if over the verbosity threshold.
 
         Args:
             output: Text to output
             verbosity_level: Only output if our verbosity level is >= this.
+            kwargs: Any additional keyword args to pass to click.echo
         """
         if verbosity_level <= self.verbosity:
-            click.echo(output)
+            click.secho(output, **kwargs)
 
-    def echo_v(self, output):
+    def echo_v(self, output, **kwargs):
         """
         Echo the given output if verbosity level is >= 1.
 
         Args:
             output: Text to output
+            kwargs: Any additional keyword args to pass to click.echo
         """
-        self.echo(output, 1)
+        self.echo(output, 1, **kwargs)
 
-    def echo_vv(self, output):
+    def echo_vv(self, output, **kwargs):
         """
         Echo the given output if verbosity level is >= 2.
 
         Args:
             output: Text to output
+            kwargs: Any additional keyword args to pass to click.echo
         """
-        self.echo(output, 2)
+        self.echo(output, 2, **kwargs)
 
-    def echo_vvv(self, output):
+    def echo_vvv(self, output, **kwargs):
         """
         Echo the given output if verbosity level is >= 3.
 
         Args:
             output: Text to output
+            kwargs: Any additional keyword args to pass to click.echo
         """
-        self.echo(output, 3)
+        self.echo(output, 3, **kwargs)
 
 
 def clean_abs_path(filename_to_clean, parent_path):


### PR DESCRIPTION
Also adds a comment to the top of the safelist to clarify that
annotations need to be added and highlights that fact in the seed
safelist command.