### PR TITLE
Fix a bug with default safelist generation

### DIFF
--- a/code_annotations/__init__.py
+++ b/code_annotations/__init__.py
@@ -4,4 +4,4 @@ Extensible tools for parsing annotations in codebases.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/code_annotations/find_django.py
+++ b/code_annotations/find_django.py
@@ -73,8 +73,8 @@ class DjangoSearch(BaseSearch):
 # fake_app_2.FakeModel2:
 #    ".. choice_annotation::": foo, bar, baz
 
-            """
-            safelist_file.write(safelist_comment.strip())
+"""
+            safelist_file.write(safelist_comment.lstrip())
             yaml_ordered_dump(safelist_data, stream=safelist_file, default_flow_style=False)
 
         self.echo('Successfully created safelist file "{}".'.format(self.config.safelist_path), fg='red')


### PR DESCRIPTION
The first model would appear in the default comment, fix is to only `lstrip` the comment, leaving the intended whitespace.
