### PR TITLE
Change double colons to single in examples

### DIFF
--- a/.annotations_sample
+++ b/.annotations_sample
@@ -3,14 +3,14 @@ report_path: reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/code_annotations/find_django.py
+++ b/code_annotations/find_django.py
@@ -69,9 +69,9 @@ class DjangoSearch(BaseSearch):
 # See https://code-annotations.readthedocs.io/en/latest/safelist.html for more information.
 #
 # fake_app_1.FakeModelName:
-#    ".. no_pii::": "This model has no PII"
+#    ".. no_pii:": "This model has no PII"
 # fake_app_2.FakeModel2:
-#    ".. choice_annotation::": foo, bar, baz
+#    ".. choice_annotation:": foo, bar, baz
 
 """
             safelist_file.write(safelist_comment.lstrip())

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -10,15 +10,15 @@ Configuring Code Annotations is a pretty simple affair. Here is an example showi
     safelist_path: .annotation_safe_list.yml
     coverage_target: 100.0
     annotations:
-        ".. annotation_token::":
-        ".. annotation_token2::":
-        ".. choice_annotation::":
+        ".. annotation_token:":
+        ".. annotation_token2:":
+        ".. choice_annotation:":
             choices: [choice_1, choice_2, choice_3]
         name_of_annotation_group:
-            - ".. first_group_token::":
-            - ".. second_group_token::":
+            - ".. first_group_token:":
+            - ".. second_group_token:":
                 choices: [choice_4, choice_5]
-            - ".. third_group_token::":
+            - ".. third_group_token:":
                 choices: [choice_a, choice_b, choice_c, choice_d]
     extensions:
         python:

--- a/docs/django_search.rst
+++ b/docs/django_search.rst
@@ -79,15 +79,15 @@ And one that has been annotated:
 .. code-block:: yaml
 
     social_django.Association:
-      ".. no_pii::": "This model has no PII"
+      ".. no_pii:": "This model has no PII"
     social_django.Code:
-      ".. pii::": "Email address"
-      ".. pii_types::": other
-      ".. pii_retirement::": local_api
+      ".. pii:": "Email address"
+      ".. pii_types:": other
+      ".. pii_retirement:": local_api
 
 .. note::
     Note that each model can only have one annotation for each token type. For example, it would be invalid to add a
-    second ``.. no_pii::`` annotation to ``social_django.Association``.
+    second ``.. no_pii:`` annotation to ``social_django.Association``.
 
 .. important::
     Some types of "local" models are procedurally generated and do not have files in code, e.g. models created by

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -20,7 +20,7 @@ Create a configuration file
 Configuration for code-annotations is done via a yaml file, The default filename of which is ``.annotations``. The
 following is an example of a minimal configuration file. See ``.annotations_sample`` for a more thorough example and
 :doc:`configuration` for more details. In this example the Code Annotations tools will search for the string
-``.. annotation_token::`` in the comments of Python and Javascript files using the built-in extensions.
+``.. annotation_token:`` in the comments of Python and Javascript files using the built-in extensions.
 
 .. code-block:: yaml
 
@@ -40,7 +40,7 @@ following is an example of a minimal configuration file. See ``.annotations_samp
     # Definitions of the annotations to search for. Notice the trailing colon, this is a mapping type!
     # For more information see "Writing Annotations"
     annotations:
-        ".. annotation_token::":
+        ".. annotation_token:":
 
     # Code Annotations extensions to load and the file extensions to map them to
     extensions:
@@ -57,20 +57,20 @@ In your ``source_path`` add some comments with annotations in them. Examples:
 .. code-block:: python
 
     """
-    .. annotation_token:: This comment text will be captured along with the token in our search.
+    .. annotation_token: This comment text will be captured along with the token in our search.
     """
 
-    # .. annotation_token:: This comment will also be captured.
+    # .. annotation_token: This comment will also be captured.
 
 **Javascript**
 
 .. code-block:: javascript
 
     /*
-    .. annotation_token:: So will this.
+    .. annotation_token: So will this.
     */
 
-    // .. annotation_token:: And this!
+    // .. annotation_token: And this!
 
 
 Run a static annotation search

--- a/docs/static_search.rst
+++ b/docs/static_search.rst
@@ -42,7 +42,7 @@ annotations, grouped by file. Each annotation entry has the following keys:
         'found_by': 'python',  # The name of the extension which found the annotation
         'filename': 'foo/bar/file.py',  # The filename where the extension was found
         'line_number': 101,  # The line number of the beginning of the comment which contained the annotation
-        'annotation_token': '.. no_pii::',  # The annotation token found
+        'annotation_token': '.. no_pii:',  # The annotation token found
         'annotation_data': 'This model contains no PII.',  # The comment, or choices, found with the annotation token
     }
 

--- a/docs/writing_annotations.rst
+++ b/docs/writing_annotations.rst
@@ -7,8 +7,8 @@ comments into two parts- the annotation token, and the annotation data.
 
 - Annotation token
     The annotation token is a unique string that can be easily found and separated from other comment content. The
-    convention used in our examples is ``.. <descriptor>::`` where <descriptor> is a slug that says the kind of
-    annotation it is. The ``..`` and ``::`` are entirely optional, but do help keep the strings unique and prevent false
+    convention used in our examples is ``.. <descriptor>:`` where <descriptor> is a slug that says the kind of
+    annotation it is. The ``..`` and ``:`` are entirely optional, but do help keep the strings unique and prevent false
     positives.
 
 - Annotation data
@@ -21,7 +21,7 @@ Django Model Search only looks in model docstrings.
 
 **Examples**
 
-Configuration for a "fun fact" annotation type, denoted by the annotation token ``.. fun_fact::``:
+Configuration for a "fun fact" annotation type, denoted by the annotation token ``.. fun_fact:``:
 
 .. code-block:: yaml
 
@@ -36,7 +36,7 @@ in Python like this:
     """
     This function handles setting the price on an item in the database.
 
-    .. fun_fact:: This code is the only remaining piece of our first commit!
+    .. fun_fact: This code is the only remaining piece of our first commit!
     """
 
 When a report is run against this code an entry like this will be generated in the YAML report:
@@ -44,29 +44,29 @@ When a report is run against this code an entry like this will be generated in t
 .. code-block:: yaml
 
     - annotation_data: This code is the only remaining piece of our first commit!
-      annotation_token: '.. fun_fact::'
+      annotation_token: '.. fun_fact:'
       filename: foo/bar/something.py
       found_by: python
       line_number: 33
 
 *Note that the rest of the comment is ignored in the report.*
 
-Configuration for an "async" annotation type, denoted by the annotation token ``.. async::`` and choices denoting the
+Configuration for an "async" annotation type, denoted by the annotation token ``.. async:`` and choices denoting the
 types of asynchronous processors hooked up to it:
 
 .. code-block:: yaml
 
     annotations:
-         ".. async::": choices: ['reporting_ingestion', 'published_internally', 'published_externally']
+         ".. async:": choices: ['reporting_ingestion', 'published_internally', 'published_externally']
 
-This means that any ``.. async::`` annotation must include one or more of those choices. With these Python comments:
+This means that any ``.. async:`` annotation must include one or more of those choices. With these Python comments:
 
 .. code-block:: python
 
     """
     Push this update onto the marketing site's processing queue
 
-    .. async:: published_internally
+    .. async: published_internally
     """
 
 .. code-block:: python
@@ -74,7 +74,7 @@ This means that any ``.. async::`` annotation must include one or more of those 
     """
     Push this to our reporting queue and the partner reporting queue
 
-    .. async:: reporting_ingestion, published_externally
+    .. async: reporting_ingestion, published_externally
     """
 
 .. code-block:: python
@@ -82,7 +82,7 @@ This means that any ``.. async::`` annotation must include one or more of those 
     """
     Push to both the wiki RSS feed and our home page
 
-    .. async:: published_internally published_externally
+    .. async: published_internally published_externally
     """
 
 This will be generated in the YAML report:
@@ -91,21 +91,21 @@ This will be generated in the YAML report:
 
     - annotation_data:
         - published_internally
-      annotation_token: '.. async::'
+      annotation_token: '.. async:'
       filename: foo/bar/data.py
       found_by: python
       line_number: 12
     - annotation_data:
         - reporting_ingestion
         - published_externally
-      annotation_token: '.. async::'
+      annotation_token: '.. async:'
       filename: foo/bar/reporting.py
       found_by: python
       line_number: 13
     - annotation_data:
         - published_internally
         - published_externally
-      annotation_token: '.. async::'
+      annotation_token: '.. async:'
       filename: foo/bar/rss.py
       found_by: python
       line_number: 333
@@ -117,7 +117,7 @@ If a comment is made that does not include only valid choices, such as:
     """
     Push this to our reporting queue
 
-    .. async:: This one only goes to our reporting queue
+    .. async: This one only goes to our reporting queue
     """
 
 You will receive a linting error such as:
@@ -128,7 +128,7 @@ You will receive a linting error such as:
     1 errors:
     ---------------------------------
 
-    foo/bar/data.py::17: "This" is not a valid choice for ".. async::". Expected one of ['reporting_ingestion', 'published_internally', 'published_externally'].
+    foo/bar/data.py::17: "This" is not a valid choice for ".. async:". Expected one of ['reporting_ingestion', 'published_internally', 'published_externally'].
 
 Annotation Groups
 =================
@@ -138,17 +138,17 @@ that all group members are consecutive, though ordering does not matter.
 
 **Examples**
 
-With this configuration there is a group of 3 annotations that must occur together. ``.. reporting::`` and
-``.. reporting_consumers::`` are free form text types and ``.. reporting_types::`` is a choice type.
+With this configuration there is a group of 3 annotations that must occur together. ``.. reporting:`` and
+``.. reporting_consumers:`` are free form text types and ``.. reporting_types:`` is a choice type.
 
 .. code-block:: yaml
 
     annotations:
         reporting:
-            - ".. reporting::"
-            - ".. reporting_types::":
+            - ".. reporting:"
+            - ".. reporting_types:":
                 choices: [internal, partner]
-            - ".. reporting_consumers::"
+            - ".. reporting_consumers:"
 
 With this comment:
 
@@ -157,9 +157,9 @@ With this comment:
     """
     Send an event to the reporting engine, for internal events only
 
-    .. reporting:: Reporting events for the mobile app
-    .. reporting_types:: internal
-    .. reporting_consumers:: Recommendations and email marketing events
+    .. reporting: Reporting events for the mobile app
+    .. reporting_types: internal
+    .. reporting_consumers: Recommendations and email marketing events
     """
 
 You would get this in the report:
@@ -168,18 +168,18 @@ You would get this in the report:
 
     openedx/core/djangoapps/user_api/legacy_urls.py:
      - annotation_data: Reporting events for the mobile app
-       annotation_token: '.. reporting::'
+       annotation_token: '.. reporting:'
        filename: foo/bar/events.py
        found_by: python
        line_number: 16
      - annotation_data:
        - internal
-       annotation_token: '.. reporting_types::'
+       annotation_token: '.. reporting_types:'
        filename: foo/bar/events.py
        found_by: python
        line_number: 16
      - annotation_data: Recommendations and email marketing events
-       annotation_token: '.. reporting_consumers::'
+       annotation_token: '.. reporting_consumers:'
        filename: openedx/core/djangoapps/user_api/legacy_urls.py
        found_by: python
        line_number: 18
@@ -191,8 +191,8 @@ This comment also works even though the ordering is different:
     """
     Send an event to the reporting engine, for internal events only
 
-    .. reporting_types:: internal
-    .. reporting:: Reporting events for the mobile app
-    .. reporting_consumers:: Recommendations and email marketing events
+    .. reporting_types: internal
+    .. reporting: Reporting events for the mobile app
+    .. reporting_consumers: Recommendations and email marketing events
     """
 

--- a/tests/extensions/javascript_test_files/choice_failures_1.js
+++ b/tests/extensions/javascript_test_files/choice_failures_1.js
@@ -1,6 +1,6 @@
 /*
 Test bad choice alone
 
-.. ignored:: doesnotexist
+.. ignored: doesnotexist
 
 */

--- a/tests/extensions/javascript_test_files/choice_failures_2.js
+++ b/tests/extensions/javascript_test_files/choice_failures_2.js
@@ -1,6 +1,6 @@
 /*
 Test bad choice with good choice
 
-.. ignored:: terrible, doesnotexist
+.. ignored: terrible, doesnotexist
 
 */

--- a/tests/extensions/javascript_test_files/choice_failures_3.js
+++ b/tests/extensions/javascript_test_files/choice_failures_3.js
@@ -1,5 +1,5 @@
 /*
 Test bad delimiter
-.. ignored:: terrible|silly-silly
+.. ignored: terrible|silly-silly
 
 */

--- a/tests/extensions/javascript_test_files/choice_failures_4.js
+++ b/tests/extensions/javascript_test_files/choice_failures_4.js
@@ -1,5 +1,5 @@
 /*
 Test duplicate choice
-.. ignored:: terrible silly-silly terrible
+.. ignored: terrible silly-silly terrible
 
  */

--- a/tests/extensions/javascript_test_files/choice_failures_5.js
+++ b/tests/extensions/javascript_test_files/choice_failures_5.js
@@ -1,5 +1,5 @@
 /*
 Test no choices given
-.. ignored::
+.. ignored:
 
  */

--- a/tests/extensions/javascript_test_files/group_failures_1.js
+++ b/tests/extensions/javascript_test_files/group_failures_1.js
@@ -1,7 +1,7 @@
 /*
 Test group missing the last item
 
-.. pii:: Group 2 - Annotation 1
-.. pii_types:: id, name
+.. pii: Group 2 - Annotation 1
+.. pii_types: id, name
 
 */

--- a/tests/extensions/javascript_test_files/group_failures_2.js
+++ b/tests/extensions/javascript_test_files/group_failures_2.js
@@ -1,7 +1,7 @@
 /*
 Test group missing the first item
 
-.. pii_retirement:: local_api, consumer_api
-.. pii_types:: id, name
+.. pii_retirement: local_api, consumer_api
+.. pii_types: id, name
 
 */

--- a/tests/extensions/javascript_test_files/group_failures_4.js
+++ b/tests/extensions/javascript_test_files/group_failures_4.js
@@ -3,8 +3,8 @@ Test for when something unexpected appears in the middle of a group.
 */
 
 /*
-.. pii:: Group 1 - Annotation 1
-.. pii_types:: id, name
-.. no_pii::
-.. pii_retirement:: local_api, consumer_api
+.. pii: Group 1 - Annotation 1
+.. pii_types: id, name
+.. no_pii:
+.. pii_retirement: local_api, consumer_api
  */

--- a/tests/extensions/javascript_test_files/group_failures_5.js
+++ b/tests/extensions/javascript_test_files/group_failures_5.js
@@ -3,8 +3,8 @@ Test for duplicates in a group
 */
 
 /*
-.. pii:: Group 1 - Annotation 1
-.. pii_types:: id, name
-.. pii_types:: id, name
-.. pii_retirement:: local_api, consumer_api
+.. pii: Group 1 - Annotation 1
+.. pii_types: id, name
+.. pii_types: id, name
+.. pii_retirement: local_api, consumer_api
  */

--- a/tests/extensions/javascript_test_files/group_ordering_1.js
+++ b/tests/extensions/javascript_test_files/group_ordering_1.js
@@ -1,8 +1,8 @@
 /*
 Test group out of order
 
-.. pii:: Group 1 - Annotation 1
-.. pii_retirement:: local_api, consumer_api
-.. pii_types:: id, name
+.. pii: Group 1 - Annotation 1
+.. pii_retirement: local_api, consumer_api
+.. pii_types: id, name
 
 */

--- a/tests/extensions/javascript_test_files/group_ordering_2.js
+++ b/tests/extensions/javascript_test_files/group_ordering_2.js
@@ -5,26 +5,26 @@ Test that a change in group ordering doesn't break following groups
 /*
 Group ordered as defined in configuration
 
-.. pii:: Group 1 - Annotation 1
-.. pii_types:: id, name
-.. pii_retirement:: local_api, consumer_api
+.. pii: Group 1 - Annotation 1
+.. pii_types: id, name
+.. pii_retirement: local_api, consumer_api
 
 */
 
 /*
 Differently ordered group
 
-.. pii:: Group 2 - Annotation 1
-.. pii_retirement:: local_api, consumer_api
-.. pii_types:: id, name
+.. pii: Group 2 - Annotation 1
+.. pii_retirement: local_api, consumer_api
+.. pii_types: id, name
 
 */
 
 /*
 Group ordered as defined in configuration
 
-.. pii:: Group 3 - Annotation 1
-.. pii_types:: id, name
-.. pii_retirement:: local_api, consumer_api
+.. pii: Group 3 - Annotation 1
+.. pii_types: id, name
+.. pii_retirement: local_api, consumer_api
 
 */

--- a/tests/extensions/javascript_test_files/simple_success.js
+++ b/tests/extensions/javascript_test_files/simple_success.js
@@ -1,62 +1,62 @@
-/* .. pii:: Group 1 - Annotation 1 */
-// .. pii_types:: id, name
-// .. pii_retirement:: local_api, consumer_api
+/* .. pii: Group 1 - Annotation 1 */
+// .. pii_types: id, name
+// .. pii_retirement: local_api, consumer_api
 
 'use strict';
 
-/* .. no_pii:: No Group 1 */
+/* .. no_pii: No Group 1 */
 var foo = require('foo');
 
 var bar = [
     something.check('foo', 'narf'),
     /foo\/js/,
     /*
-    .. pii:: Group 2 - Annotation 1 comment is a
+    .. pii: Group 2 - Annotation 1 comment is a
     multi line comment
     */
-    // .. pii_types:: id, name
-    // .. pii_retirement:: local_api, consumer_api
+    // .. pii_types: id, name
+    // .. pii_retirement: local_api, consumer_api
     /pii\/js/,
-    // .. pii:: Group 3 - Annotation 1
-    // .. pii_types:: id, name
-// .. pii_retirement:: local_api, consumer_api
+    // .. pii: Group 3 - Annotation 1
+    // .. pii_types: id, name
+// .. pii_retirement: local_api, consumer_api
     /common\/lib\/xmodule\/xmodule\/js\/src\//
 ];
 
 something.pii = SomethingElse.do_it({
-    // .. no_pii:: No Group 2
+    // .. no_pii: No Group 2
 
     context: "nothing",
 
     taco: {
         Foo: 'just another pii'
     }
-}); // .. no_pii:: No Group 3
+}); // .. no_pii: No Group 3
 
 /*
 Text above token
 
-.. pii:: Group 4 - Annotation 1
-.. pii_types:: id, name
-.. pii_retirement:: local_api, consumer_api
+.. pii: Group 4 - Annotation 1
+.. pii_types: id, name
+.. pii_retirement: local_api, consumer_api
 
 Text below token
 */
 
 // These check different ways of doing options
-// .. ignored:: silly-silly,terrible, irrelevant
-// .. ignored:: terrible irrelevant silly-silly
+// .. ignored: silly-silly,terrible, irrelevant
+// .. ignored: terrible irrelevant silly-silly
 
-/* .. pii:: Group 5 - Annotation 1
-.. pii_types:: id, name
-.. pii_retirement:: local_api, consumer_api */
+/* .. pii: Group 5 - Annotation 1
+.. pii_types: id, name
+.. pii_retirement: local_api, consumer_api */
 
 /*
-* .. pii:: Group 6 - Annotation 1
-* .. pii_types:: id, name
-* .. pii_retirement:: local_api, consumer_api
+* .. pii: Group 6 - Annotation 1
+* .. pii_types: id, name
+* .. pii_retirement: local_api, consumer_api
 */
 
-/*.. pii:: Group 7 - Annotation 1
-.. pii_types:: id, name
-.. pii_retirement:: local_api, consumer_api*/
+/*.. pii: Group 7 - Annotation 1
+.. pii_types: id, name
+.. pii_retirement: local_api, consumer_api*/

--- a/tests/extensions/python_test_files/choice_failures_1.pyt
+++ b/tests/extensions/python_test_files/choice_failures_1.pyt
@@ -1,6 +1,6 @@
 """
 Test bad choice alone
 
-.. ignored:: doesnotexist
+.. ignored: doesnotexist
 
 """

--- a/tests/extensions/python_test_files/choice_failures_2.pyt
+++ b/tests/extensions/python_test_files/choice_failures_2.pyt
@@ -1,6 +1,6 @@
 """
 Test bad choice with good choice
 
-.. ignored:: terrible, doesnotexist
+.. ignored: terrible, doesnotexist
 
 """

--- a/tests/extensions/python_test_files/choice_failures_3.pyt
+++ b/tests/extensions/python_test_files/choice_failures_3.pyt
@@ -1,5 +1,5 @@
 """
 Test bad delimiter
-.. ignored:: terrible|silly-silly
+.. ignored: terrible|silly-silly
 
 """

--- a/tests/extensions/python_test_files/choice_failures_4.pyt
+++ b/tests/extensions/python_test_files/choice_failures_4.pyt
@@ -1,5 +1,5 @@
 """
 Test duplicate choice
-.. ignored:: terrible silly-silly terrible
+.. ignored: terrible silly-silly terrible
 
 """

--- a/tests/extensions/python_test_files/choice_failures_5.pyt
+++ b/tests/extensions/python_test_files/choice_failures_5.pyt
@@ -1,5 +1,5 @@
 """
 Test no choices given
-.. ignored::
+.. ignored:
 
 """

--- a/tests/extensions/python_test_files/group_failures_1.pyt
+++ b/tests/extensions/python_test_files/group_failures_1.pyt
@@ -1,7 +1,7 @@
 """
 Test group missing the last item
 
-.. pii:: Group 2 - Annotation 1
-.. pii_types:: id, name
+.. pii: Group 2 - Annotation 1
+.. pii_types: id, name
 
 """

--- a/tests/extensions/python_test_files/group_failures_2.pyt
+++ b/tests/extensions/python_test_files/group_failures_2.pyt
@@ -1,7 +1,7 @@
 """
 Test group missing the first item
 
-.. pii_retirement:: local_api, consumer_api
-.. pii_types:: id, name
+.. pii_retirement: local_api, consumer_api
+.. pii_types: id, name
 
 """

--- a/tests/extensions/python_test_files/group_ordering_1.pyt
+++ b/tests/extensions/python_test_files/group_ordering_1.pyt
@@ -1,8 +1,8 @@
 """
 Test group in a different order
 
-.. pii:: Group 1 - Annotation 1
-.. pii_retirement:: local_api, consumer_api
-.. pii_types:: id, name
+.. pii: Group 1 - Annotation 1
+.. pii_retirement: local_api, consumer_api
+.. pii_types: id, name
 
 """

--- a/tests/extensions/python_test_files/group_ordering_2.pyt
+++ b/tests/extensions/python_test_files/group_ordering_2.pyt
@@ -3,21 +3,21 @@ Tests that a change in group ordering doesn't break following groups
 
 Group ordered as defined in configuration
 
-.. pii:: Group 1 - Annotation 1
-.. pii_types:: id, name
-.. pii_retirement:: local_api, consumer_api
+.. pii: Group 1 - Annotation 1
+.. pii_types: id, name
+.. pii_retirement: local_api, consumer_api
 """
 """
 Differently ordered group
 
-.. pii:: Group 2 - Annotation 1
-.. pii_retirement:: local_api, consumer_api
-.. pii_types:: id, name
+.. pii: Group 2 - Annotation 1
+.. pii_retirement: local_api, consumer_api
+.. pii_types: id, name
 """
 """
 Group ordered as defined in configuration
 
-.. pii:: Group 3 - Annotation 1
-.. pii_types:: id, name
-.. pii_retirement:: local_api, consumer_api
+.. pii: Group 3 - Annotation 1
+.. pii_types: id, name
+.. pii_retirement: local_api, consumer_api
 """

--- a/tests/extensions/python_test_files/simple_success.pyt
+++ b/tests/extensions/python_test_files/simple_success.pyt
@@ -1,61 +1,61 @@
 """
 Docstring
 
-.. pii:: Annotation 1
-.. pii_types:: id, name
+.. pii: Annotation 1
+.. pii_types: id, name
 """
 # Should be able to finish the group outside of the same comment if necessary
-# .. pii_retirement:: local_api, consumer_api
+# .. pii_retirement: local_api, consumer_api
 
 
 def do():
-    """.. pii:: Annotation 2
-        .. pii_types:: id, name
-        .. pii_retirement:: local_api, consumer_api
+    """.. pii: Annotation 2
+        .. pii_types: id, name
+        .. pii_retirement: local_api, consumer_api
     """
     pass
 
 
 def re():
-    """.. pii:: Annotation 3
-    .. pii_retirement:: local_api, consumer_api
-    .. pii_types:: id, name"""
+    """.. pii: Annotation 3
+    .. pii_retirement: local_api, consumer_api
+    .. pii_types: id, name"""
     pass
 
 
 def mi():
     """
     Comment above annotation
-    .. pii:: Annotation 4
-    .. pii_types:: id, name
-    .. pii_retirement:: local_api, consumer_api
+    .. pii: Annotation 4
+    .. pii_types: id, name
+    .. pii_retirement: local_api, consumer_api
     Comment below annotation
     """
     pass
 
 
 def fa():
-    """.. no_pii:: Annotation 5"""
+    """.. no_pii: Annotation 5"""
     pass
 
 
 def so():
     """
     Test choices outside of a group
-    .. ignored:: silly-silly,terrible, irrelevant
-    .. ignored:: terrible irrelevant silly-silly
+    .. ignored: silly-silly,terrible, irrelevant
+    .. ignored: terrible irrelevant silly-silly
     """
     pass
 
 
 def la():
-    # .. pii:: Annotation 6
-    # .. pii_types:: id, name
-    # .. pii_retirement:: local_api, consumer_api
+    # .. pii: Annotation 6
+    # .. pii_types: id, name
+    # .. pii_retirement: local_api, consumer_api
     pass
 
 
 def ti():
-    # .. ignored:: silly-silly,terrible, irrelevant
-    # .. ignored:: terrible irrelevant silly-silly
+    # .. ignored: silly-silly,terrible, irrelevant
+    # .. ignored: terrible irrelevant silly-silly
     pass

--- a/tests/extensions/test_extension_javascript.py
+++ b/tests/extensions/test_extension_javascript.py
@@ -12,13 +12,13 @@ from tests.helpers import EXIT_CODE_FAILURE, EXIT_CODE_SUCCESS, call_script
     ('group_ordering_2.js', EXIT_CODE_SUCCESS, 'Search found 9 annotations in'),
     ('group_failures_1.js', EXIT_CODE_FAILURE, 'File finished with an incomplete group'),
     ('group_failures_2.js', EXIT_CODE_FAILURE, 'File finished with an incomplete group'),
-    ('group_failures_4.js', EXIT_CODE_FAILURE, '".. no_pii::" is not in the group that starts with'),
-    ('group_failures_5.js', EXIT_CODE_FAILURE, '".. pii_types::" is already in the group that starts with'),
-    ('choice_failures_1.js', EXIT_CODE_FAILURE, '"doesnotexist" is not a valid choice for ".. ignored::"'),
-    ('choice_failures_2.js', EXIT_CODE_FAILURE, '"doesnotexist" is not a valid choice for ".. ignored::"'),
-    ('choice_failures_3.js', EXIT_CODE_FAILURE, '"terrible|silly-silly" is not a valid choice for ".. ignored::"'),
+    ('group_failures_4.js', EXIT_CODE_FAILURE, '".. no_pii:" is not in the group that starts with'),
+    ('group_failures_5.js', EXIT_CODE_FAILURE, '".. pii_types:" is already in the group that starts with'),
+    ('choice_failures_1.js', EXIT_CODE_FAILURE, '"doesnotexist" is not a valid choice for ".. ignored:"'),
+    ('choice_failures_2.js', EXIT_CODE_FAILURE, '"doesnotexist" is not a valid choice for ".. ignored:"'),
+    ('choice_failures_3.js', EXIT_CODE_FAILURE, '"terrible|silly-silly" is not a valid choice for ".. ignored:"'),
     ('choice_failures_4.js', EXIT_CODE_FAILURE, '"terrible" is already present in this annotation'),
-    ('choice_failures_5.js', EXIT_CODE_FAILURE, 'No choices found for ".. ignored::"'),
+    ('choice_failures_5.js', EXIT_CODE_FAILURE, 'No choices found for ".. ignored:"'),
 ])
 def test_grouping_and_choice_failures(test_file, expected_exit_code, expected_message):
     result = call_script((

--- a/tests/extensions/test_extension_python.py
+++ b/tests/extensions/test_extension_python.py
@@ -12,11 +12,11 @@ from tests.helpers import EXIT_CODE_FAILURE, EXIT_CODE_SUCCESS, call_script
     ('group_ordering_2.pyt', EXIT_CODE_SUCCESS, 'Search found 9 annotations in'),
     ('group_failures_1.pyt', EXIT_CODE_FAILURE, 'File finished with an incomplete group'),
     ('group_failures_2.pyt', EXIT_CODE_FAILURE, 'File finished with an incomplete group'),
-    ('choice_failures_1.pyt', EXIT_CODE_FAILURE, '"doesnotexist" is not a valid choice for ".. ignored::"'),
-    ('choice_failures_2.pyt', EXIT_CODE_FAILURE, '"doesnotexist" is not a valid choice for ".. ignored::"'),
-    ('choice_failures_3.pyt', EXIT_CODE_FAILURE, '"terrible|silly-silly" is not a valid choice for ".. ignored::"'),
+    ('choice_failures_1.pyt', EXIT_CODE_FAILURE, '"doesnotexist" is not a valid choice for ".. ignored:"'),
+    ('choice_failures_2.pyt', EXIT_CODE_FAILURE, '"doesnotexist" is not a valid choice for ".. ignored:"'),
+    ('choice_failures_3.pyt', EXIT_CODE_FAILURE, '"terrible|silly-silly" is not a valid choice for ".. ignored:"'),
     ('choice_failures_4.pyt', EXIT_CODE_FAILURE, '"terrible" is already present in this annotation'),
-    ('choice_failures_5.pyt', EXIT_CODE_FAILURE, 'No choices found for ".. ignored::"'),
+    ('choice_failures_5.pyt', EXIT_CODE_FAILURE, 'No choices found for ".. ignored:"'),
 ])
 def test_grouping_and_choice_failures(test_file, expected_exit_code, expected_message):
     result = call_script((

--- a/tests/fake_models.py
+++ b/tests/fake_models.py
@@ -25,7 +25,7 @@ class FakeChildModelSingleAnnotation(FakeBaseModelNoAnnotation):
     """
     This model inherits and has one annotation.
 
-    .. no_pii:: Child model.
+    .. no_pii: Child model.
     """
 
     _meta = MagicMock(app_label='fake_app_1', object_name='FakeChildModelSingleAnnotation', abstract=False, proxy=False)
@@ -35,7 +35,7 @@ class FakeChildModelMultiAnnotation(FakeChildModelSingleAnnotation):
     """
     This model multi-level inherits and has one annotation. Its parent also has one.
 
-    .. no_pii:: Grandchild model.
+    .. no_pii: Grandchild model.
     """
 
     _meta = MagicMock(app_label='fake_app_1', object_name='FakeChildModelMultiAnnotation', abstract=False, proxy=False)
@@ -46,7 +46,7 @@ class FakeBaseModelWithAnnotation(object):
     """
     This is a fake model with one annotation.
 
-    .. no_pii:: Base model annotation.
+    .. no_pii: Base model annotation.
     """
 
     _meta = MagicMock(app_label='fake_app_2', object_name='FakeBaseModelWithAnnotation', abstract=False, proxy=False)
@@ -64,7 +64,7 @@ class FakeChildModelSingleWithAnnotation(FakeBaseModelWithAnnotation):
     """
     This model inherits and has one annotation.
 
-    .. no_pii:: Child model.
+    .. no_pii: Child model.
     """
 
     _meta = MagicMock(
@@ -79,7 +79,7 @@ class FakeChildModelMultiWithAnnotation(FakeChildModelWithAnnotation):
     """
     This model multi-level inherits and has one annotation. Its parent also has one.
 
-    .. no_pii:: Grandchild model.
+    .. no_pii: Grandchild model.
     """
 
     _meta = MagicMock(
@@ -98,8 +98,8 @@ class FakeChildModelMultiWithBrokenAnnotations(FakeChildModelWithAnnotation):
     """
     This model multi-level inherits and has one annotation. Its parent also has one.
 
-    .. pii_types:: id
-    .. pii_retirement:: retained
+    .. pii_types: id
+    .. pii_retirement: retained
     """
 
     _meta = MagicMock(
@@ -123,7 +123,7 @@ class FakeBaseModelBoringWithAnnotations(object):
     """
     This is a fake model with an annotation.
 
-    .. no_pii:: No PII.
+    .. no_pii: No PII.
     """
 
     _meta = MagicMock(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,14 +19,14 @@ report_path: test_reports
 source_path: ../
 coverage_target: 50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -55,7 +55,7 @@ def test_bad_type_in_group():
         AnnotationConfig('tests/test_configurations/.annotations_test_group_bad_type', None, 3)
 
     exc_msg = str(exception.value)
-    assert "{'.. pii::': ['bad', 'type']} is an unknown annotation type." in exc_msg
+    assert "{'.. pii:': ['bad', 'type']} is an unknown annotation type." in exc_msg
 
 
 @pytest.mark.parametrize("test_config,expected_message", [

--- a/tests/test_configurations/.annotations_test
+++ b/tests/test_configurations/.annotations_test
@@ -3,14 +3,14 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/tests/test_configurations/.annotations_test_coverage_int
+++ b/tests/test_configurations/.annotations_test_coverage_int
@@ -3,14 +3,14 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/tests/test_configurations/.annotations_test_coverage_nan
+++ b/tests/test_configurations/.annotations_test_coverage_nan
@@ -3,14 +3,14 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: not a number
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/tests/test_configurations/.annotations_test_coverage_negative
+++ b/tests/test_configurations/.annotations_test_coverage_negative
@@ -3,14 +3,14 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: -50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/tests/test_configurations/.annotations_test_coverage_none
+++ b/tests/test_configurations/.annotations_test_coverage_none
@@ -3,14 +3,14 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target:
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/tests/test_configurations/.annotations_test_coverage_over_100
+++ b/tests/test_configurations/.annotations_test_coverage_over_100
@@ -3,14 +3,14 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 150.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/tests/test_configurations/.annotations_test_group_bad_type
+++ b/tests/test_configurations/.annotations_test_group_bad_type
@@ -3,11 +3,11 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
+        - ".. pii:":
             - bad
             - type
 extensions:

--- a/tests/test_configurations/.annotations_test_group_no_annotations
+++ b/tests/test_configurations/.annotations_test_group_no_annotations
@@ -3,8 +3,8 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group": []
 extensions:

--- a/tests/test_configurations/.annotations_test_missing_coverage_target
+++ b/tests/test_configurations/.annotations_test_missing_coverage_target
@@ -2,14 +2,14 @@ source_path: tests/extensions/javascript_test_files/
 report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/tests/test_configurations/.annotations_test_missing_extension
+++ b/tests/test_configurations/.annotations_test_missing_extension
@@ -3,14 +3,14 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     does_not_exist:

--- a/tests/test_configurations/.annotations_test_missing_report_path
+++ b/tests/test_configurations/.annotations_test_missing_report_path
@@ -2,14 +2,14 @@ source_path: ../devstack-docker/edx-platform
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     javascript:

--- a/tests/test_configurations/.annotations_test_missing_safelist_path
+++ b/tests/test_configurations/.annotations_test_missing_safelist_path
@@ -2,14 +2,14 @@ source_path: tests/extensions/javascript_test_files/
 report_path: test_reports
 coverage_target: 50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/tests/test_configurations/.annotations_test_missing_source_path
+++ b/tests/test_configurations/.annotations_test_missing_source_path
@@ -2,14 +2,14 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     javascript:

--- a/tests/test_configurations/.annotations_test_python_only
+++ b/tests/test_configurations/.annotations_test_python_only
@@ -3,14 +3,14 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50.0
 annotations:
-    ".. no_pii::":
-    ".. ignored::":
+    ".. no_pii:":
+    ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
-        - ".. pii::":
-        - ".. pii_types::":
+        - ".. pii:":
+        - ".. pii_types:":
             choices: [id, name, other]
-        - ".. pii_retirement::":
+        - ".. pii_retirement:":
             choices: [retained, local_api, consumer_api, third_party]
 extensions:
     python:

--- a/tests/test_find_django.py
+++ b/tests/test_find_django.py
@@ -61,7 +61,7 @@ def test_find_django_simple_success(**kwargs):
 
     fake_safelist = """
     fake_app_2.FakeBaseModelWithNoDocstring:
-        ".. no_pii::": "No PII"
+        ".. no_pii:": "No PII"
     """
 
     result = call_script_isolated(
@@ -182,7 +182,7 @@ def test_find_django_model_in_safelist_annotated(**kwargs):
 
     fake_safelist_data = """
     {
-        fake_app_1.FakeBaseModelNoAnnotation: {".. no_pii::": "This model is annotated."}
+        fake_app_1.FakeBaseModelNoAnnotation: {".. no_pii:": "This model is annotated."}
     }
     """
 
@@ -237,7 +237,7 @@ def test_find_django_in_safelist_and_annotated(**kwargs):
 
     result = call_script_isolated(
         ['django_find_annotations', '--config_file', 'test_config.yml', '--lint', '--report'],
-        fake_safelist_data='{{{}: ".. no_pii::"}}'.format(DjangoSearch.get_model_id(FakeBaseModelWithAnnotation))
+        fake_safelist_data='{{{}: ".. no_pii:"}}'.format(DjangoSearch.get_model_id(FakeBaseModelWithAnnotation))
     )
 
     assert result.exit_code == EXIT_CODE_FAILURE
@@ -294,7 +294,7 @@ def test_find_django_ordering_error(**kwargs):
     )
 
     assert result.exit_code == EXIT_CODE_FAILURE
-    assert '".. no_pii::" is not in the group ' in result.output
+    assert '".. no_pii:" is not in the group ' in result.output
 
 
 @patch.multiple(


### PR DESCRIPTION
**Description:** Changing things over to use one colon instead of two across the annotations to prevent issues with docstring publication tools. These should only be changes to our examples throughout the codebase.