### PR TITLE
Improve annotation configuration checks, make coverage_target optional

### DIFF
--- a/code_annotations/cli.py
+++ b/code_annotations/cli.py
@@ -6,7 +6,7 @@ import traceback
 
 import click
 
-from code_annotations.base import AnnotationConfig
+from code_annotations.base import AnnotationConfig, ConfigurationException
 from code_annotations.find_django import DjangoSearch
 from code_annotations.find_static import StaticSearch
 from code_annotations.helpers import fail
@@ -61,6 +61,10 @@ def django_find_annotations(
         start_time = datetime.datetime.now()
         config = AnnotationConfig(config_file, report_path, verbosity)
         searcher = DjangoSearch(config)
+
+        # Early out if we're trying to do coverage, but a coverage target is not configured
+        if coverage and not config.coverage_target:
+            raise ConfigurationException("Please add 'coverage_target' to your configuration before running --coverage")
 
         if seed_safelist:
             searcher.seed_safelist()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -31,7 +31,6 @@ def test_get_group_for_token_multiple_groups():
     ('.annotations_test_missing_source_path', "source_path"),
     ('.annotations_test_missing_report_path', "report_path"),
     ('.annotations_test_missing_safelist_path', "safelist_path"),
-    ('.annotations_test_missing_coverage_target', 'coverage_target')
 ])
 def test_missing_config(test_config, expected_message):
     with pytest.raises(ConfigurationException) as exception:
@@ -42,27 +41,10 @@ def test_missing_config(test_config, expected_message):
     assert expected_message in exc_msg
 
 
-def test_empty_group():
-    with pytest.raises(TypeError) as exception:
-        AnnotationConfig('tests/test_configurations/.annotations_test_group_no_annotations', None, 3)
-
-    exc_msg = str(exception.value)
-    assert 'Group "pii_group" has no annotations' in exc_msg
-
-
-def test_bad_type_in_group():
-    with pytest.raises(TypeError) as exception:
-        AnnotationConfig('tests/test_configurations/.annotations_test_group_bad_type', None, 3)
-
-    exc_msg = str(exception.value)
-    assert "{'.. pii:': ['bad', 'type']} is an unknown annotation type." in exc_msg
-
-
 @pytest.mark.parametrize("test_config,expected_message", [
     ('.annotations_test_coverage_negative', "Invalid coverage target. -50.0 is not between 0 and 100."),
     ('.annotations_test_coverage_over_100', "Invalid coverage target. 150.0 is not between 0 and 100."),
     ('.annotations_test_coverage_nan', 'Coverage target must be a number between 0 and 100 not "not a number".'),
-    ('.annotations_test_coverage_none', 'Coverage target must be a number between 0 and 100 not "None".'),
 ])
 def test_bad_coverage_targets(test_config, expected_message):
     with pytest.raises(ConfigurationException) as exception:
@@ -75,3 +57,18 @@ def test_bad_coverage_targets(test_config, expected_message):
 def test_coverage_target_int():
     # We just care that this doesn't throw an exception
     AnnotationConfig('tests/test_configurations/{}'.format('.annotations_test_coverage_int'), None, 3)
+
+
+@pytest.mark.parametrize("test_config,expected_message", [
+    ('.annotations_test_duplicate_token', ".. no_pii: is configured more than once, tokens must be unique."),
+    ('.annotations_test_duplicate_token_2_groups', ".. no_pii: is configured more than once, tokens must be unique."),
+    ('.annotations_test_group_no_annotations', 'Group "pii_group" must have more than one annotation.'),
+    ('.annotations_test_group_one_token', 'Group "pii_group" must have more than one annotation.'),
+    ('.annotations_test_group_bad_type', "{'.. pii:': ['bad', 'type']} is an unknown annotation type."),
+])
+def test_annotation_configuration_errors(test_config, expected_message):
+    with pytest.raises(ConfigurationException) as exception:
+        AnnotationConfig('tests/test_configurations/{}'.format(test_config), None, 3)
+
+    exc_msg = str(exception.value)
+    assert expected_message in exc_msg

--- a/tests/test_configurations/.annotations_test_duplicate_token
+++ b/tests/test_configurations/.annotations_test_duplicate_token
@@ -8,11 +8,11 @@ annotations:
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
         - ".. pii:":
-            - bad
-            - type
         - ".. pii_types:":
-            - bad
-            - type
+            choices: [id, name, other]
+        - ".. pii_retirement:":
+            choices: [retained, local_api, consumer_api, third_party]
+        - ".. no_pii:":
 extensions:
     python:
         - pyt

--- a/tests/test_configurations/.annotations_test_duplicate_token_2_groups
+++ b/tests/test_configurations/.annotations_test_duplicate_token_2_groups
@@ -3,16 +3,18 @@ report_path: test_reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50.0
 annotations:
-    ".. no_pii:":
     ".. ignored:":
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
         - ".. pii:":
-            - bad
-            - type
         - ".. pii_types:":
-            - bad
-            - type
+            choices: [id, name, other]
+        - ".. pii_retirement:":
+            choices: [retained, local_api, consumer_api, third_party]
+        - ".. no_pii:":
+    "group_2":
+        - ".. no_pii:":
+        - ".. foo:":
 extensions:
     python:
         - pyt

--- a/tests/test_configurations/.annotations_test_group_one_token
+++ b/tests/test_configurations/.annotations_test_group_one_token
@@ -8,11 +8,6 @@ annotations:
         choices: [irrelevant, terrible, silly-silly]
     "pii_group":
         - ".. pii:":
-            - bad
-            - type
-        - ".. pii_types:":
-            - bad
-            - type
 extensions:
     python:
         - pyt


### PR DESCRIPTION
**Description:** Perform basic checks to make sure configured annotations will work correctly, and make the `coverage_target` configuration variable optional (but checked before use).