### PR TITLE
Fix setup instructions, test requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ quality: ## check coding style with pycodestyle and pylint
 
 requirements: ## install development environment requirements
 	pip install -qr requirements/pip-tools.txt
-	pip-sync requirements/dev.txt requirements/private.*
+	pip-sync requirements/dev.txt requirements/test.txt requirements/private.*
+	pip install -e .
 
 test: clean ## run tests in the current virtualenv
 	pytest

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -7,12 +7,13 @@ below is executed within the virtualenv.
 .. _virtualenv: https://virtualenvwrapper.readthedocs.org/en/latest/
 
 
-Install the tool
-----------------
+Install the requirements
+------------------------
+This will also install the Code Annotations package as editable, to allow access to the Stevedore plugins.
+
 .. code-block:: bash
 
     $ make requirements
-    $ pip install -e .
 
 
 Run the tests


### PR DESCRIPTION
**Description:** Re-enables the ability to run pytest / "make test" out of the box.

**Testing instructions:**

1. Create a new virtualenv and source it
2. In the Code Annotations top level directory run a `make requirements`
3. Run `make test` all tests should succeed
4. Run `pytest` all tests should succeed
5. Confirm that the "Getting Started" doc roughly adequately describes how to install the app and run tests.
