### PR TITLE
[BD-21] Add support for warnings in the `featuretoggles` Sphinx extension

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[0.5.1] - 2020-08-25
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add support for warnings in the ``featuretoggles`` Sphinx extension
+
 [0.5.0] - 2020-08-06
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/code_annotations/__init__.py
+++ b/code_annotations/__init__.py
@@ -2,4 +2,4 @@
 Extensible tools for parsing annotations in codebases.
 """
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/code_annotations/config_and_tools/sphinx/extensions/featuretoggles.py
+++ b/code_annotations/config_and_tools/sphinx/extensions/featuretoggles.py
@@ -115,6 +115,10 @@ class FeatureToggles(SphinxDirective):
                 ),
             )
             yield nodes.paragraph(text=toggle.get(".. toggle_description:", ""))
+            if toggle.get(".. toggle_warnings:") not in (None, "None", "n/a", "N/A"):
+                yield nodes.warning(
+                    "", nodes.paragraph("", toggle[".. toggle_warnings:"])
+                )
 
 
 def quote_value(value):


### PR DESCRIPTION
**Description:** Add support for `toggle_warning` flags in the `featuretoggles` Sphinx extension

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943

**Dependencies:** None. But useful for documenting edx-platform feature toggles.

**Reviewers:**
- [ ] @robrap 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- ~~[ ] Documentation updated (not only docstrings)~~
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
