### PR TITLE
[BD-21] Get rid of the `documented_elsewhere` annotation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[0.9.0] - 2020-09-25
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Get rid of the ``documented_elsewhere`` annotation, which is used nowhere
+
+
 [0.8.0] - 2020-09-10
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/code_annotations/__init__.py
+++ b/code_annotations/__init__.py
@@ -2,4 +2,4 @@
 Extensible tools for parsing annotations in codebases.
 """
 
-__version__ = '0.8.0'
+__version__ = '0.9.0'

--- a/code_annotations/contrib/config/feature_toggle_annotations.yaml
+++ b/code_annotations/contrib/config/feature_toggle_annotations.yaml
@@ -5,9 +5,6 @@ report_path: reports
 safelist_path: .annotation_safe_list.yml
 coverage_target: 50.0
 annotations:
-  documented_elsewhere:
-    - ".. documented_elsewhere:":
-    - ".. documented_elsewhere_name:":
   feature_toggle:
     - ".. toggle_name:":
     - ".. toggle_implementation:":


### PR DESCRIPTION
**Description:** This is nowhere used. If we need to re-introduce it at some point, we'll
discuss it then.

**JIRA:** BD-21 https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943

**Reviewers:**
- [x] @robrap 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] ~~Documentation updated (not only docstrings)~~
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
