### PR TITLE
Adding incremental_release as another option for toggle_use_case

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[unreleased] - 2020-11-06
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Adding incremental_release as another option for toggle_use_case
+Alot of toggles in edx-platform are labeled incremental_release, which seems like a valid choice.
+And this use case didn't seem captured by options that previously existed.
+
 [0.10.0] - 2020-10-12
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/code_annotations/base.py
+++ b/code_annotations/base.py
@@ -425,7 +425,6 @@ class BaseSearch(object, metaclass=ABCMeta):
         for filename in all_results:
             current_group = None
             found_group_members = []
-
             for annotation in all_results[filename]:
                 self._check_results_choices(annotation)
                 token = annotation['annotation_token']
@@ -478,9 +477,8 @@ class BaseSearch(object, metaclass=ABCMeta):
                     self.echo.echo_vv("Group complete!")
                     current_group = None
                     found_group_members = []
-
             if current_group:
-                self.errors.append('File finished with an incomplete group {}!'.format(current_group))
+                self.errors.append('{}: File finished with an incomplete group {}!'.format(filename, current_group))
 
         return not self.errors
 

--- a/code_annotations/contrib/config/feature_toggle_annotations.yaml
+++ b/code_annotations/contrib/config/feature_toggle_annotations.yaml
@@ -13,7 +13,7 @@ annotations:
     - ".. toggle_default:":
     - ".. toggle_description:":
     - ".. toggle_use_cases:":
-        choices: [temporary, circuit_breaker, vip, opt_out, opt_in, open_edx]
+        choices: [incremental_release, temporary, circuit_breaker, vip, opt_out, opt_in, open_edx]
     - ".. toggle_creation_date:":
     - ".. toggle_target_removal_date:":
     - ".. toggle_warnings:":


### PR DESCRIPTION
Alot of toggles in edx-platform are labeled incremental_release, which seems like a valid choice.
And this use case didn't seem captured by options that previously existed.
