### PR TITLE
[BD-21] Fix grouping of safelisted annotations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,12 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
-[1.0.0] - 2021-01-25
+[1.0.1] - 2021-01-22
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Fix grouping of safelisted annotations
+
+[1.0.0] - 2021-01-21
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * BREAKING CHANGE: Improvement of some error messages

--- a/code_annotations/__init__.py
+++ b/code_annotations/__init__.py
@@ -2,4 +2,4 @@
 Extensible tools for parsing annotations in codebases.
 """
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/code_annotations/base.py
+++ b/code_annotations/base.py
@@ -447,23 +447,28 @@ class BaseSearch(metaclass=ABCMeta):
         """
         Iterate on groups of annotations.
 
-        Annotations are considered as a group when they all have the same `line_number`, which should point to the
-        beginning of the annotation group.
+        Annotations are considered as a group when they all have the same `line_number` and optional
+        `extra['object_id']`. The line number points to the beginning of the annotation group. The `object_id` is set
+        mostly for annotations parsed from a safelist.
 
         Yield:
             annotations (annotation list)
         """
         current_group = []
         current_line_number = None
+        current_object_id = None
         for annotation in annotations:
             line_number = annotation["line_number"]
+            object_id = annotation.get("extra", {}).get("object_id")
             line_number_changed = line_number != current_line_number
-            if line_number_changed:
+            object_id_changed = object_id != current_object_id
+            if line_number_changed or object_id_changed:
                 if current_group:
                     yield current_group
                 current_group.clear()
             current_group.append(annotation)
             current_line_number = line_number
+            current_object_id = object_id
 
         if current_group:
             yield current_group


### PR DESCRIPTION
Annotation grouping was based on the filename and line number. Unfortunately,
this fails when the annotation comes from the safelist, where the filename is
the safelist, and the line number is 0. This was causing issues in pii
annotation parsing on edx-platform. To address this, we group annotations by
line number and extra[model_id] fields.

**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

The following command was triggering errors for all safelisted annotations:

```
DJANGO_SETTINGS_MODULE=lms.envs.test code_annotations django_find_annotations --config_file .pii_annotations.yml --app_name lms --lint
```

It now reports only the following errors:

```
Search failed due to linting errors!
4 errors:
---------------------------------
celery_utils.FailedTask is annotated, but also in the safelist.
/home/regis/venvs/openedx/lib/python3.8/site-packages/edx_proctoring/models.py::edx_proctoring.ProctoredExamSoftwareSecureReview: "to_be_implemented" is not a valid choice for ".. pii_retirement:". Expected one of ['retained', 'local_api', 'consumer_api', 'third_party'].
/home/regis/venvs/openedx/lib/python3.8/site-packages/edx_proctoring/models.py::edx_proctoring.ProctoredExamSoftwareSecureComment: "to_be_implemented" is not a valid choice for ".. pii_retirement:". Expected one of ['retained', 'local_api', 'consumer_api', 'third_party'].
/home/regis/venvs/openedx/lib/python3.8/site-packages/edx_proctoring/models.py::edx_proctoring.ProctoredExamSoftwareSecureReviewHistory: "to_be_implemented" is not a valid choice for ".. pii_retirement:". Expected one of ['retained', 'local_api', 'consumer_api', 'third_party'].
```

**Reviewers:**
- [ ] @robrap 
- [ ] @bmedx 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)