### PR TITLE
make setting_warning annotation optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[1.0.2] - 2021-01-22
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Make setting_warning annotation optional.
+
 [1.0.1] - 2021-01-22
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/code_annotations/__init__.py
+++ b/code_annotations/__init__.py
@@ -2,4 +2,4 @@
 Extensible tools for parsing annotations in codebases.
 """
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'

--- a/code_annotations/contrib/config/setting_annotations.yaml
+++ b/code_annotations/contrib/config/setting_annotations.yaml
@@ -7,6 +7,7 @@ annotations:
     - ".. setting_default:":
     - ".. setting_description:":
     - ".. setting_warning:":
+        optional: true
 extensions:
     python:
         - py


### PR DESCRIPTION
**Description:**

make setting_warning annotation optional

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

