### PR TITLE
Remove click constraint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+[1.1.2] - 2021-05-21
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Django is not a base requirement for the package now.
+* Removed the click constraint from base requirements.
+
 [1.1.1] - 2021-03-30
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/code_annotations/__init__.py
+++ b/code_annotations/__init__.py
@@ -2,4 +2,4 @@
 Extensible tools for parsing annotations in codebases.
 """
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 
 -c constraints.txt
 
-click>=7.0,<8.0
+click
 Jinja2
 pyyaml
 python-slugify


### PR DESCRIPTION
## Description
- Remove click constraint from `base.in` file.
- Bump the version to `1.1.2`.

## Reason
- Requirements upgrade jobs in several packages are failing due to the base constraint of `click<8.0` required in the code-annotations package. 
- code-annotations has constraint `click<8.0` in `base.in` file which is being used in `edx-lint` latest version and `edx-lint` is in-turn being used in code-annotations. This makes it a circular dependency so we can't run make upgrade along with removing the constraint. 
- After merging this PR, the code-annotations version will be changed in `edx-lint` which will remove the effect of circular dependencies and hence will allow us to update the requirements. 

## Testing 
- The change is verified to resolve the upgrade issue by using the hash commit of this PR in the edx-lint sample branch https://github.com/edx/edx-lint/tree/usamasadiq/remove-code-annotations-constraint  and then using that branch's latest commit on local code-annotations repo for running the make upgrade script.